### PR TITLE
use 16k model when more than 3000 words

### DIFF
--- a/src/components/settings/summarizers/OpenAI.tsx
+++ b/src/components/settings/summarizers/OpenAI.tsx
@@ -87,7 +87,7 @@ const OpenAISettings = ({ settings, dispatch }: SettingsFormProps) => {
         ></input>
       </div>
       <p className="text-sm text-gray-500 mt-2">
-        <span>Content afterwards will be truncated, napkin upper bound for GPT-3.5-turbo: (4096-96) / 100 * 75 ~= 3000</span>
+        <span>Longer content will feed to 16k context model, napkin threshold for GPT-3.5-turbo: (4096-96) / 100 * 75 ~= 3000</span>
       </p>
     </div>
   );

--- a/src/lib/api/openai.ts
+++ b/src/lib/api/openai.ts
@@ -22,8 +22,13 @@ export const getCompletion = async (
   apikey: string,
   messages: ChatMessage[]
 ): Promise<string> => {
+  const words = messages
+    .map((x) => x.content.split(" ").length)
+    .reduce((a, b) => a + b);
+
   const payload = {
-    model: "gpt-3.5-turbo", // not changing anytime soon
+    // see napkin math in OpenAI.tsx
+    model: words > 3000 ? "gpt-3.5-turbo-16k" : "gpt-3.5-turbo",
     temperature: 0,
     messages: messages,
   };

--- a/src/lib/summarizers/utils.test.ts
+++ b/src/lib/summarizers/utils.test.ts
@@ -4,4 +4,9 @@ describe("sanitize string", () => {
   test("replace multiple spaces to one", () => {
     expect(sanitizeContent("a   b  c\n\nd")).toBe("a b c d");
   });
+
+  test("truncate to first K words split by spaces", () => {
+    expect(sanitizeContent("a   b  c\n\nd", 2)).toBe("a b");
+    expect(sanitizeContent("a   b  c\n\nd", 4)).toBe("a b c d");
+  });
 });

--- a/src/lib/summarizers/utils.ts
+++ b/src/lib/summarizers/utils.ts
@@ -1,8 +1,5 @@
 export const sanitizeContent = (content: string, limit = 0): string => {
-  const text = content.replaceAll(/\s+/g, " ");
-  if (limit != 0) {
-    return text.slice(0, limit);
-  }
-
-  return text;
+  const textSlices = content.replaceAll(/\s+/g, " ").split(" ");
+  const truncateSlices = limit === 0 ? textSlices : textSlices.slice(0, limit);
+  return truncateSlices.join(" ");
 };


### PR DESCRIPTION
breaking change: previously `sanitizeContent` truncates by chars

price change when the user sets max token to higher than 3000

Model | Input | Output
-- | -- | --
4K context | $0.0015 / 1K tokens | $0.002 / 1K tokens
16K context | $0.003 / 1K tokens | $0.004 / 1K tokens

