### PR TITLE
fix: disable auto summary doesn't work

### DIFF
--- a/src/components/settings/general_settings.tsx
+++ b/src/components/settings/general_settings.tsx
@@ -2,7 +2,7 @@ import { SettingsFormProps } from "@components/types";
 import { SyntheticEvent } from "react";
 
 const GeneralSettings = ({ settings, dispatch }: SettingsFormProps) => {
-  const { general = { autoSummary: false } } = settings;
+  const { general } = settings;
 
   const handleChangeAutoSummary = (event: SyntheticEvent<HTMLInputElement>) => {
     dispatch({
@@ -17,7 +17,7 @@ const GeneralSettings = ({ settings, dispatch }: SettingsFormProps) => {
         <input
           type="checkbox"
           className="swc:toggle"
-          defaultChecked={general.autoSummary}
+          defaultChecked={!!general?.autoSummary}
           onChange={handleChangeAutoSummary}
         />
         <span className="swc:text-base">Auto Generate Summary on Open</span>

--- a/src/pages/content/main.tsx
+++ b/src/pages/content/main.tsx
@@ -61,7 +61,7 @@ const Main = () => {
   const summary = useQuery({
     queryKey: ["summary"],
     queryFn: () => fetchSummary(doc.data!),
-    enabled: settings?.general?.autoSummary,
+    enabled: !!settings?.general?.autoSummary,
   });
 
   const mutation = useMutation({ mutationFn: doExport });

--- a/src/pages/content/main.tsx
+++ b/src/pages/content/main.tsx
@@ -61,8 +61,7 @@ const Main = () => {
   const summary = useQuery({
     queryKey: ["summary"],
     queryFn: () => fetchSummary(doc.data!),
-    enabled:
-      !!doc.data && hasSelectedSummarizer && settings?.general?.autoSummary,
+    enabled: settings?.general?.autoSummary,
   });
 
   const mutation = useMutation({ mutationFn: doExport });


### PR DESCRIPTION
mystery bug, but since refetch works when the enabled = false, so it's safe to set it to false if we don't want auto summary.